### PR TITLE
Added option to prevent having STDERR in output

### DIFF
--- a/lib/Gnuplot/Builder/Process.pm
+++ b/lib/Gnuplot/Builder/Process.pm
@@ -69,6 +69,10 @@ sub wait_all {
 ## async (BOOL optional, default = false): If set to true, it won't
 ## wait for the gnuplot process to finish. In this case, the return
 ## value is an empty string.
+##
+## no_error (BOOL optional, default = false): If set to true, it won't
+## include gnuplot's warnings or errors in the output and just ignores
+## them.
 sub with_new_process {
     my ($class, %args) = @_;
     my $code = $args{do};
@@ -99,6 +103,9 @@ sub with_new_process {
 ## capture (BOOL optional, default: false): If true, it keeps the
 ## STDOUT and STDERR of the process so that it can read them
 ## afterward. Otherwise, it just discards the output.
+##
+## no_error (BOOL optional, default: false): If true, STDERR is discarded
+## instead of being redirected to STDOUT.
 sub _new {
     my ($class, %args) = @_;
     _clear_zombies();
@@ -297,6 +304,12 @@ By default, it's C<0> (false).
 
 You can also set this variable by the environment variable
 C<PERL_GNUPLOT_BUILDER_PROCESS_ASYNC>.
+
+=head2 $NOERROR
+
+If set to true, gnuplot's STDERR will not appear in the result. You can use this to prevent warnings in the output.
+
+By default it is C<0>, to be compatible with older versions.
 
 =head2 @COMMAND
 

--- a/lib/Gnuplot/Builder/Process.pm
+++ b/lib/Gnuplot/Builder/Process.pm
@@ -20,7 +20,7 @@ sub _get_env {
 }
 
 our $ASYNC = _get_env("ASYNC", 0);
-our $NOERROR = _get_env("NOERROR", 0);
+our $NOSTDERR = _get_env("NOSTDERR", 0);
 our @COMMAND = _get_env("COMMAND", qw(gnuplot --persist));
 our $MAX_PROCESSES = _get_env("MAX_PROCESSES", 2);
 our $PAUSE_FINISH = _get_env("PAUSE_FINISH", 0);
@@ -78,8 +78,8 @@ sub with_new_process {
     my $code = $args{do};
     croak "do parameter is mandatory" if !defined($code);
     my $async = defined($args{async}) ? $args{async} : $ASYNC;
-    my $no_error = defined($args{no_error}) ? $args{no_error} : $NOERROR;
-    my $process = $class->_new(capture => !$async, no_error => $no_error);
+    my $no_stderr = defined($args{no_stderr}) ? $args{no_stderr} : $NOSTDERR;
+    my $process = $class->_new(capture => !$async, no_stderr => $no_stderr);
     my $result = "";
     try {
         $code->($process->_writer);
@@ -117,13 +117,13 @@ sub _new {
         $proc->_waitpid(1);
     }
     my $capture = $args{capture};
-    my $no_error = $args{no_error};
+    my $no_stderr = $args{no_stderr};
     my ($write_handle, $read_handle, $pid);
 
     ## open3() does not seem to work well with lexical filehandles, so we use fileno()
     $pid = open3($write_handle,
                  $capture ? $read_handle : '>&'.fileno(_null_handle()),
-                 $no_error ? '>&'.fileno(_null_handle()) : undef, @COMMAND);
+                 $no_stderr ? '>&'.fileno(_null_handle()) : undef, @COMMAND);
     my $self = bless {
         pid => $pid,
         write_handle => $write_handle,

--- a/lib/Gnuplot/Builder/Script.pm
+++ b/lib/Gnuplot/Builder/Script.pm
@@ -431,6 +431,10 @@ If it's set, C<@set_args> is directly given to C<set()> method.
 
 Most object methods return the object itself, so that you can chain those methods.
 
+=head2 $builder->set_no_error($error)
+
+Enable or disable errors and warnings in the output.
+
 =head2 $script = $builder->to_string()
 
 Build and return the gnuplot script string.

--- a/lib/Gnuplot/Builder/Script.pm
+++ b/lib/Gnuplot/Builder/Script.pm
@@ -13,7 +13,7 @@ sub new {
     my $self = bless {
         pdata => undef,
         parent => undef,
-        no_error => 0,
+        no_stderr => 0,
     };
     $self->_init_pdata();
     if(@set_args) {
@@ -37,9 +37,9 @@ sub _init_pdata {
     );
 }
 
-sub set_no_error {
-    my ($self, $no_error) = @_;
-    $self->{no_error}     = $no_error;
+sub set_no_stderr {
+    my ($self, $no_stderr) = @_;
+    $self->{no_stderr}     = $no_stderr;
 }
 
 sub add {
@@ -350,7 +350,7 @@ sub run_with {
     }elsif(defined($_context_writer)) {
         $do->($_context_writer);
     }else {
-        $result = Gnuplot::Builder::Process->with_new_process(async => $async, do => $do, no_error => $self->{no_error});
+        $result = Gnuplot::Builder::Process->with_new_process(async => $async, do => $do, no_stderr => $self->{no_stderr});
     }
     return $result;
 }

--- a/lib/Gnuplot/Builder/Script.pm
+++ b/lib/Gnuplot/Builder/Script.pm
@@ -13,6 +13,7 @@ sub new {
     my $self = bless {
         pdata => undef,
         parent => undef,
+        no_error => 0,
     };
     $self->_init_pdata();
     if(@set_args) {
@@ -34,6 +35,11 @@ sub _init_pdata {
             }
         }
     );
+}
+
+sub set_no_error {
+    my ($self, $no_error) = @_;
+    $self->{no_error}     = $no_error;
 }
 
 sub add {
@@ -337,13 +343,14 @@ sub run_with {
             }
         }
     };
+
     my $result = "";
     if(defined($args{writer})) {
         $do->($args{writer});
     }elsif(defined($_context_writer)) {
         $do->($_context_writer);
     }else {
-        $result = Gnuplot::Builder::Process->with_new_process(async => $async, do => $do);
+        $result = Gnuplot::Builder::Process->with_new_process(async => $async, do => $do, no_error => $self->{no_error});
     }
     return $result;
 }

--- a/t/process/stderr.t
+++ b/t/process/stderr.t
@@ -7,11 +7,11 @@ use Gnuplot::Builder::Script;
 use Gnuplot::Builder::Dataset;
 
 sub create_builder {
-    my ($no_error) = @_;
+    my ($no_stderr) = @_;
     my $builder = Gnuplot::Builder::Script->new(
         terminal => 'dumb',
     );
-    $builder->set_no_error($no_error);
+    $builder->set_no_stderr($no_stderr);
     return $builder;
 }
 

--- a/t/process/stderr.t
+++ b/t/process/stderr.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings FATAL => "all";
+use lib "t";
+use testlib::ScriptUtil qw(plot_str);
+use Test::More;
+use Gnuplot::Builder::Script;
+use Gnuplot::Builder::Dataset;
+
+sub create_builder {
+    my ($no_error) = @_;
+    my $builder = Gnuplot::Builder::Script->new(
+        terminal => 'dumb',
+    );
+    $builder->set_no_error($no_error);
+    return $builder;
+}
+
+{
+    my $builder = create_builder(0);
+    my $dataset = Gnuplot::Builder::Dataset->new_data(
+        sub {
+            my ( $dataset, $writer ) = @_;
+
+            for ( 1 .. 10 ) {
+                $writer->("$_ 10\n");
+            }
+        },
+        with  => "lines",
+        title => "'xyz'",
+    );
+    my $ret_err = $builder->plot($dataset);
+    like ($ret_err, qr/Warning/, "Test for stderr-output");
+}
+
+{
+    my $builder = create_builder(1);
+    my $dataset = Gnuplot::Builder::Dataset->new_data(
+        sub {
+            my ( $dataset, $writer ) = @_;
+
+            for ( 1 .. 10 ) {
+                $writer->("$_ 10\n");
+            }
+        },
+        with  => "lines",
+        title => "'xyz'",
+    );
+    my $ret_noerr = $builder->plot($dataset);
+    unlike ($ret_noerr, qr/Warning/, "Test for no stderr-output");
+}
+done_testing;


### PR DESCRIPTION
This will behave just like before but you can now use
```
Gnuplot::Builder::Script->set_no_error(1);
```

to disable warnings in the output.

We use this library to generate plots automatically and we don't want
errors in there. Maybe it is useful to more people.